### PR TITLE
Update pip dependencies

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,22 +1,22 @@
 # Flask
-Flask==1.0.2
-Flask-Caching==1.4.0
-Flask-Classful==0.14.1
-flask-cors==3.0.6
-Flask-Migrate==2.4.0
+Flask==1.0.3
+Flask-Caching==1.7.2
+Flask-Classful==0.14.2
+flask-cors==3.0.8
+Flask-Migrate==2.5.2
 Flask-Script==2.0.6
-Flask-SQLAlchemy==2.3.2
-werkzeug==0.14
+Flask-SQLAlchemy==2.4.0
+werkzeug==0.15.4
 
 # Cache
 redis==2.10.6
 
 # Gateway
-uWSGI==2.0.17.1
+uWSGI==2.0.18
 
 # Database things
 PyMySQL==0.9.3
-SQLAlchemy==1.3.3
+SQLAlchemy==1.3.5
 jsonpatch==1.23
 dictalchemy==0.1.2.7
 


### PR DESCRIPTION
Update pip requirements to latest versions as of today. Redis 3.x will be added separately as it is backwards incompatible.